### PR TITLE
Better error handling for secondary scripts and Fix for Issue #110

### DIFF
--- a/bin/createClient
+++ b/bin/createClient
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -63,16 +64,9 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GsDevKit_todeClient project has not been installed correctly or the"
-  echo "GS_TODE_CLIENT environment variable has not been defined"
-  exit 1
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
 fi
 
 postFixArg=""
@@ -97,12 +91,12 @@ while getopts ":fhp:z:cv:Ds:y:l" OPT ; do
     y) smalltalkCIProjectPathArg=" -y ${OPTARG} ";;
     D) debugArg=" -D ";;
     ?) postFixArg=" -p ";;          # handle optional -p argument "
-    *) usage; exit 1;;
+    *) usage; exit_1_banner "Uknown option";;
   esac
 done
 shift $(($OPTIND - 1))
 if [ $# -lt 1 ]; then
-  usage; exit 1
+  usage; exit_1_banner "Missing required positional parameter"
 fi
 clientName=$1
 
@@ -110,7 +104,7 @@ case $version in
   Pharo*) 
     $GS_TODE_CLIENT/bin/createPharoTodeClient $clientArg $lockMetacelloArg $smalltalkCIProjectPathArg $smalltalkCIArg $debugArg $sessionNameArg $forceArg $postFixArg -v $version $clientName
     ;;
-  *) echo "Unknown client version: $version"; usage; exit 1;;
+  *) usage; exit_1_banner "Unknown client version: $version";;
 esac
 
-echo "...finished $(basename $0)"
+exit_0_banner "...finished"

--- a/bin/createPharoTodeClient
+++ b/bin/createPharoTodeClient
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -64,16 +65,9 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GsDevKit_todeClient project has not been installed correctly or the"
-  echo "GS_TODE_CLIENT environment variable has not been defined"
-  exit 1
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
 fi
 source ${GS_HOME}/bin/private/winRunPharoFunctions
 
@@ -99,13 +93,13 @@ while getopts ":fhp:z:cv:Ds:y:l" OPT ; do
     y) smalltalkCIProjectPath="${OPTARG}";;
     D) debugMode="true";;
     ?) postFixArg=" -p ";;          # handle optional -p argument "
-    *) usage; exit 1;;
+    *) usage; exit_1_banner "Uknown option";;
   esac
 done
 shift $(($OPTIND - 1))
 
 if [ $# -lt 1 ]; then
-  usage; exit 1
+  usage; exit_1_banner "Missing required positional parameter"
 fi
 clientName=$1
 directoryPath=$GS_CLIENT_DEV_CLIENTS/$clientName
@@ -124,11 +118,14 @@ imageName=${clientName}${postFix}
 if [ -e $directoryPath/todeClient${postFix}.image ] ; then
   # old-style tode client
   imageName="todeClient${postFix}"
+else
+  if [ -e $directoryPath/${imageName}.image ] ; then
+    clientImage="true"
+  fi
 fi
 if [ -e $directoryPath/${imageName}.image ] ; then
   if [ "${force}x" = "x" ] ; then
-    echo "client image already created, use -f to force update"
-    exit 0
+    exit_0_banner "client image already created, use -f to force update"
   else
     message="update"
   fi
@@ -251,7 +248,7 @@ else
       (Smalltalk at: #SCIGemStoneServerConfigSpec) defaultSessionName: sessionName
     "
   else
-    echo "${imageName} image not updated --- update manually"
+    exit_0_banner "${imageName} image not updated --- update manually"
   fi
   $pharoCmd $directoryPath/clientTmp.image save $imageName
 
@@ -260,4 +257,5 @@ else
 
   $GS_HOME/bin/private/scanProductsForInstallingGciLibs $directoryPath
 fi
-echo "...finished $(basename $0)"
+
+exit_0_banner "...finished"

--- a/bin/createPharoTodeClient
+++ b/bin/createPharoTodeClient
@@ -193,7 +193,7 @@ else
 
   if [ "${smalltalkCIPath}x" != "x" ] ; then
     echo "${message} ${imageName} image using $smalltalkCIPath"
-    $createPharoCmd $directoryPath/clientTmp.image eval --save "
+    cat - > $directoryPath/customClientLoad.st << EOF
       | ci sessionName projectPath |
       [  Metacello new
           baseline: 'Metacello';
@@ -203,25 +203,25 @@ else
         Metacello new
           baseline: 'Metacello';
           repository: '${GS_SHARED_REPO_METACELLO}';
-	  lock. \"unconditionally lock Metacello\"
+	  lock. "unconditionally lock Metacello"
         Metacello new
           baseline: 'Ston';
           repository: '${GS_SHARED_REPO_STON}';
-	  lock. \"unconditionally lock Ston\"
+	  lock. "unconditionally lock Ston"
       '${loadGsDevKitClient}' isEmpty
         ifTrue: [
-          \"If GsDevKitClient isn't present (GsDevKit_home not updated to latest), load only SmalltalkCI\"
+          "If GsDevKitClient isn't present (GsDevKit_home not updated to latest), load only SmalltalkCI"
           Metacello new
             baseline: 'SmalltalkCI';
             repository: '${GS_SHARED_REPO_SMALLTALKCI}';
             onConflict: [:ex | ex allow];
             load ]
         ifFalse: [
-          \"If GsDevKitClient is present, lock SmalltalkCI and load GsDevKitClient\"
+          "If GsDevKitClient is present, lock SmalltalkCI and load GsDevKitClient"
           Metacello new
             baseline: 'SmalltalkCI';
             repository: '${GS_SHARED_REPO_SMALLTALKCI}';
-            lock.  \"explicitly lock before loading GsDevKitClient\"
+            lock.  "explicitly lock before loading GsDevKitClient"
   	  Metacello new
             baseline: 'TodeClient';
             repository: '${GS_SHARED_REPO_TODE_CLIENT}';
@@ -239,17 +239,20 @@ else
 	       loadCIFor: '${smalltalkCIPath}'
 	       projectDirectory: projectPath ] ]
 	         on: MetacelloAllowLockedProjectChange
-	         do: [:ex | ex disallow \"honor\"].
+	         do: [:ex | ex disallow "honor"].
       '${sessionName}' isEmpty
         ifTrue: [ 
           (ci compatibleConfigurationsFor: #gemstoneClient) do: [:configSpec |
             configSpec defaultSessionName ifNotNil: [:sessName |  sessionName := sessName ]]]
 	ifFalse: [ sessionName := '${sessionName}' ].
       (Smalltalk at: #SCIGemStoneServerConfigSpec) defaultSessionName: sessionName
-    "
+EOF
   else
-    exit_0_banner "${imageName} image not updated --- update manually"
+    if [ ! -e "$directoryPath/customClientLoad.st" ] ; then
+      exit_0_banner "${imageName} image not updated --- update manually"
+    fi
   fi
+  $createPharoCmd $directoryPath/clientTmp.image --quit --save $directoryPath/customClientLoad.st
   $pharoCmd $directoryPath/clientTmp.image save $imageName
 
   echo""

--- a/bin/createPharoTodeClient
+++ b/bin/createPharoTodeClient
@@ -228,6 +228,7 @@ else
   	  Metacello new
             baseline: 'TodeClient';
             repository: '${GS_SHARED_REPO_TODE_CLIENT}';
+            lock;
             onConflict: [:ex | ex allow];
             load: 'GsDevKitClient' ].
       '${lockMetacelloRepositories}' isEmpty not

--- a/bin/deleteClient
+++ b/bin/deleteClient
@@ -38,4 +38,4 @@ clientName=$1
 
 rm -rf $GS_CLIENT_DEV_CLIENTS/$clientName
 
-exit_1_banner "...finished"
+exit_0_banner "...finished"

--- a/bin/deleteClient
+++ b/bin/deleteClient
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -25,22 +26,16 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 if [ "${GS_CLIENT_DEV}x" = "x" ] ; then
-  echo "the GS_CLIENT_DEV environment variable needs to be defined"
-  exit 1
+  exit_1_banner "the GS_CLIENT_DEV environment variable needs to be defined"
 fi
 
 if [ $# -lt 1 ]; then
-  usage; exit 1
+  usage; exit_1_banner "Missing required positional parameter"
 fi
 clientName=$1
 
 rm -rf $GS_CLIENT_DEV_CLIENTS/$clientName
 
-echo "...finished $(basename $0)"
+exit_1_banner "...finished"

--- a/bin/updateGsDevKit
+++ b/bin/updateGsDevKit
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -23,10 +24,8 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GS_TODE_CLIENT environment variable needs to be defined"
-  exit 1
+  exit_1_banner "the GS_TODE_CLIENT environment variable needs to be defined"
 fi
 source ${GS_HOME}/bin/defGsDevKit.env
 
@@ -34,4 +33,4 @@ targetDir=$1
 
 cp -rf ${GS_TODE_CLIENT}/template/* $targetDir
 
-echo "...finished $(basename $0)"
+exit_0_banner "...finished"

--- a/template/clientInfo
+++ b/template/clientInfo
@@ -1,7 +1,12 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
+
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
 
 usage() {
   cat <<HELP
@@ -20,22 +25,15 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GsDevKit_todeClient project has not been installed correctly or the"
-  echo "GS_TODE_CLIENT environment variable has not been defined"
-  exit 1
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
 fi
 
 while getopts "h" OPT ; do
   case "$OPT" in
     h) usage; exit 0 ;;
-     *) usage; exit 1 ;;
+    *) usage; exit_1_banner "Uknown option";;
   esac
 done
 shift $(($OPTIND - 1))

--- a/template/deleteClient
+++ b/template/deleteClient
@@ -1,6 +1,8 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015, 2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
 

--- a/template/installClientGciLibraries
+++ b/template/installClientGciLibraries
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2014, 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2014, 2015, 2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -25,17 +26,12 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"; exit 1
-fi
-
 if [ $# -ne 1 ]; then
-  usage; exit 1
+  usage; exit_1_banner "Missing required positional parameter"
 fi
 vers="$1"
 scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 $GS_HOME/bin/private/installGci -d $scriptDir -t pharo $vers
 
-echo "...finished $(basename $0)"
+exit_0_banner "...finished"

--- a/template/startClient
+++ b/template/startClient
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -45,16 +46,9 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GsDevKit_todeClient project has not been installed correctly or the"
-  echo "GS_TODE_CLIENT environment variable has not been defined"
-  exit 1
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
 fi
 source ${GS_HOME}/bin/private/winRunPharoFunctions
 
@@ -78,7 +72,7 @@ while getopts "fhp:s:z:t:r" OPT ; do
     t) testSuiteName="${OPTARG}";;
     r) showCIResults="true";;
     z) smalltalkCIPath="${OPTARG}"; smalltalkCIArg=" -c -z ${OPTARG} ";;
-    *) usage; exit 1 ;;
+    *) usage; exit_1_banner "Uknown option";;
   esac
 done
 shift $(($OPTIND - 1))
@@ -126,17 +120,14 @@ case "$PLATFORM" in
     pharoCmd="win_run_pharo $scriptDir "
     ciPharoCmd="win_run_pharo $scriptDir --headless "
     ;;
-  *)
-    echo "unsupported platform: $PLATFORM"
-    exit 1
-    ;;
+  *) exit_1_banner "unsupported platform: $PLATFORM" ;;
 esac
 
 unset GEMSTONE_NRS_ALL
 
 if [ "${testSuiteName}x" != "x" ] ; then 
   if [ "${smalltalkCIPath}x" = "x" ] ; then
-    echo "Required -z option not specified"; usage; exit 1
+    usage; exit_1_banner "Required -z option not specified"
   fi
   $ciPharoCmd $scriptDir/${imageName}.image eval "
       | ci sessionName |
@@ -168,4 +159,4 @@ else
   fi
 fi
 
-echo "...finished $(basename $0)"
+exit_0_banner "...finished"

--- a/template/updateClient
+++ b/template/updateClient
@@ -1,22 +1,20 @@
 #! /bin/bash
+
+#! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
-set -e # exit on error
-if [ "${GS_HOME}x" = "x" ] ; then
-  echo "the GS_HOME environment variable needs to be defined"
-  exit 1
-fi
 source ${GS_HOME}/bin/defGsDevKit.env
 
 if [ $# -lt 1 ]; then
-  echo "missing reguired argument <client-name>"; usage; exit 1
+  exit_1_banner "missing reguired argument <client-name>"
 fi
 clientName="$1"
 scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -38,4 +36,4 @@ pushd $scriptDir >& /dev/null
 
 popd >& /dev/null
 
-echo "...finished $(basename $0)"
+exit_0_banner "...finished"

--- a/template/updateGsDevKit
+++ b/template/updateGsDevKit
@@ -33,4 +33,4 @@ scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 ${GS_TODE_CLIENT}/bin/updateGsDevKit $scriptDir
 
-exit_0_bannter "...finished"
+exit_0_banner "...finished"

--- a/template/updateGsDevKit
+++ b/template/updateGsDevKit
@@ -1,12 +1,13 @@
 #! /bin/bash
 #=========================================================================
-# Copyright (c) 2015 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
 #=========================================================================
 
-echo "================="
-echo "   GsDevKit script: $(basename $0) $*"
-echo "              path: $0"
-echo "================="
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
 
 usage() {
   cat <<HELP
@@ -23,10 +24,8 @@ EXAMPLES
 HELP
 }
 
-set -e # exit on error
 if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
-  echo "the GS_TODE_CLIENT environment variable needs to be defined"
-  exit 1
+  exit_1_banner "the GS_TODE_CLIENT environment variable needs to be defined"
 fi
 source ${GS_HOME}/bin/defGsDevKit.env
 
@@ -34,4 +33,4 @@ scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 ${GS_TODE_CLIENT}/bin/updateGsDevKit $scriptDir
 
-echo "...finished $(basename $0)"
+exit_0_bannter "...finished"


### PR DESCRIPTION
All _home scripts are now have improved error handling in addition to `_todeClient` changes:
- [_gs_server](https://github.com/GsDevKit/GsDevKit_gs_server/commit/b20d18e38c76d6bf72925abd49410cf7a22331ae)
- [_gs_client_dev](https://github.com/GsDevKit/GsDevKit_gs_client_dev/commit/4b2d50380ec552525e3c9ce3aca8fab25cd9b927)
- [_sys_local](https://github.com/GsDevKit/GsDevKit_sys_local/commit/f2fd6a6d5249b17ab0b27e7dbf940e162afe35c0)
## Bugfixes
1. Issue [#95](https://github.com/GsDevKit/GsDevKit_home/issues/95): Install should return a short final status line
2. Issue [#110](https://github.com/GsDevKit/GsDevKit_home/issues/110): updateGsDevKit tries to load `tode.st` into non-tode clients
## Update Script

```
updateGsDevKit -g # delete and re-create any non-tODE clients that you may have created
```
## [Previous Pull Request](https://github.com/dalehenrich/tode/pull/256)
