### PR TITLE
stopClient and editClient scripts

### DIFF
--- a/template/editClient
+++ b/template/editClient
@@ -1,0 +1,109 @@
+#! /bin/bash
+#=========================================================================
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
+#=========================================================================
+
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
+
+usage() {
+  cat <<HELP
+USAGE: $(basename $0) [-h] [-p <postfix>] 
+                      [-s <session-description-name>]
+                      <client-name>
+                      <script>
+
+Launch todeClient image, evaluates <script> string, saves the image and quits.
+
+OPTIONS
+  -h 
+     display help
+  -p <postfix>
+     Launch the tode client image created with a matching postfix. If
+     the tode client image does not exist, build it.
+  -s <session-description-name>
+     Assume that client was created with -z option specified, use <session-description-name> to 
+     override the default session name specified in the original <smalltalkCI-smalltalk.ston-path> file.
+
+EXAMPLES
+  $(basename $0) -h
+  $(basename $0) tode "ZnZincServer startOn: 8080." # Evaluates script on the image named todeClient_0.image
+  $(basename $0) -p _0 tode "ZnZincServer startOn: 8080." # Evaluates script on the image named todeClient_0.image
+
+HELP
+}
+
+source ${GS_HOME}/bin/defGsDevKit.env
+if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
+fi
+source ${GS_HOME}/bin/private/winRunPharoFunctions
+
+scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+postFix=""
+sessionName=""
+postFixArg=""
+script=""
+while getopts "hp:s:" OPT ; do
+  case "$OPT" in
+    h) usage; exit 0 ;;
+    p) postFix="${OPTARG}"; postFixArg=" -p ${OPTARG} ";;
+    s) sessionName="${OPTARG}";;
+    *) usage; exit_1_banner "Uknown option";;
+  esac
+done
+shift $(($OPTIND - 1))
+
+clientName=$1
+imageName=${clientName}${postFix}
+
+script=$2
+if [ "${script}x" = "x" ]; then
+	usage
+	exit_1_banner "No script given"
+fi
+
+if [ ! -e $scriptDir/${imageName}.image ] ; then
+  if [ ! -e $scriptDir/todeClient${postFix}.image ] ; then
+    echo "The requested client image: $scriptDir/${imageName}.image does not exist"
+    exit 1
+  else
+    # pre-existing old-style image
+    imageName=todeClient${postFix}
+  fi
+fi
+
+# Detect operating system
+PLATFORM="`uname -sm | tr ' ' '-'`"
+# Macs with Core i7 use the same software as older Macs
+[ $PLATFORM = "Darwin-x86_64" ] && PLATFORM="Darwin-i386"
+
+case "$PLATFORM" in
+  Darwin-i386|Linux-x86_64) 
+    pharoCmd="$scriptDir/pharo --headless"
+    ;; 
+  MSYS_NT*|MINGW32_NT*|MINGW64_NT*) 
+    paroCmd="win_run_pharo $scriptDir --headless "
+    ;;
+  *) exit_1_banner "unsupported platform: $PLATFORM" ;;
+esac
+
+unset GEMSTONE_NRS_ALL
+
+runScript="${script}.
+SmalltalkImage current snapshot: true andQuit: true.
+"
+
+if [ "${sessionName}x" != "x" ]; then
+  runScript="
+SCIGemStoneServerConfigSpec defaultSessionName: '${sessionName}'.
+${runScript}"
+fi
+
+$pharoCmd $scriptDir/${imageName}.image eval "${runScript}"
+
+exit_0_banner "...finished"

--- a/template/startClient
+++ b/template/startClient
@@ -185,6 +185,9 @@ else
     echo "Error starting client image ${imageName}"
     cat $scriptDir/logs/${imageName}.log
     exit 1
+  else
+    test -f $scriptDir/${imageName}.pid && rm -f $scriptDir/${imageName}.pid
+    echo $pid > $scriptDir/${imageName}.pid
   fi
 fi
 

--- a/template/stopClient
+++ b/template/stopClient
@@ -1,0 +1,86 @@
+#! /bin/bash
+#=========================================================================
+# Copyright (c) 2015,2016 GemTalk Systems, LLC <dhenrich@gemtalksystems.com>.
+#
+#   MIT license: https://github.com/GsDevKit/GsDevKit_todeClient/blob/master/license.txt
+#=========================================================================
+
+theArgs="$*"
+source ${GS_HOME}/bin/private/shFeedback
+start_banner
+
+usage() {
+  cat <<HELP
+USAGE: $(basename $0) [-h] [-f] [-p <postfix>] 
+                      [ [-s <session-description-name>] [-t <test-suite-name> [-r]] [-z <smalltalkCI-smalltalk.ston-path>] ]
+                      <client-name>
+
+Launch todeClient image.
+
+OPTIONS
+  -h 
+     display help
+  -p <postfix>
+     Launch the tode client image created with a matching postfix. If
+     the tode client image does not exist, build it.
+
+EXAMPLES
+  $(basename $0) -h
+  $(basename $0) tode # Stops all instances
+  $(basename $0) -p _0 tode # Stops instance running todeClient_0.image
+
+HELP
+}
+
+source ${GS_HOME}/bin/defGsDevKit.env
+if [ "${GS_TODE_CLIENT}x" = "x" ] ; then
+  exit_1_banner "the GsDevKit_todeClient project has not been installed correctly or the GS_TODE_CLIENT environment variable has not been defined"
+fi
+source ${GS_HOME}/bin/private/winRunPharoFunctions
+
+scriptDir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+postFix=""
+while getopts "hp:" OPT ; do
+  case "$OPT" in
+    h) usage; exit 0 ;;
+    p) postFix="${OPTARG}" ;;
+    *) usage; exit_1_banner "Uknown option";;
+  esac
+done
+shift $(($OPTIND - 1))
+
+clientName=$1
+if [ -z $clientName ]; then
+  usage; exit_1_banner "Unspecified client name"
+fi
+imageName=${clientName}${postFix}
+
+if [ "$force" = "true" ] ; then
+  $GS_TODE_CLIENT/bin/createPharoTodeClient -f $postFixArg $smalltalkCIArg $clientName
+fi
+
+pidFiles=()
+if [ "${postFix}x" != "x" ]; then
+  pidFile="${scriptDir}/${imageName}.pid"
+  test -f $pidFile || exit_1_banner "Cannot find pid file $pidFile"
+  pidFiles=($pidFile)
+else
+  pidFiles=( $(ls -1 ${scriptDir}/${imageName}*.pid 2>/dev/null || echo "" ) )
+fi
+
+if [ ${#pidFiles[@]} -eq 0 ]; then
+  exit_0_banner "No running clients found"
+fi
+
+for pidFile in ${pidFiles[@]}; do
+  cat $pidFile | while read pid; do 
+    ps -jx | grep "[${pid:0:1}]${pid:1}" | cut -d " " -f 2 | while read p; do
+      kill -TERM $p || exit_1_banner "Cannot kill process with PID: $p"
+    done
+  done
+  rm -f $pidFile
+done
+
+
+exit_0_banner "...finished"

--- a/template/stopClient
+++ b/template/stopClient
@@ -56,9 +56,16 @@ if [ -z $clientName ]; then
 fi
 imageName=${clientName}${postFix}
 
-if [ "$force" = "true" ] ; then
-  $GS_TODE_CLIENT/bin/createPharoTodeClient -f $postFixArg $smalltalkCIArg $clientName
-fi
+# Detect operating system
+PLATFORM="`uname -sm | tr ' ' '-'`"
+# Macs with Core i7 use the same software as older Macs
+[ $PLATFORM = "Darwin-x86_64" ] && PLATFORM="Darwin-i386"
+
+sedOpts="-r"
+case "$PLATFORM" in
+	Darwin-i386)
+		sedOpts="-E" ;;
+esac
 
 pidFiles=()
 if [ "${postFix}x" != "x" ]; then
@@ -75,8 +82,8 @@ fi
 
 for pidFile in ${pidFiles[@]}; do
   cat $pidFile | while read pid; do 
-    ps -jx | grep "[${pid:0:1}]${pid:1}" | cut -d " " -f 2 | while read p; do
-      kill -TERM $p || exit_1_banner "Cannot kill process with PID: $p"
+    ps -o pid,ppid | grep "[${pid:0:1}]${pid:1}" | sed ${sedOpts} "s/^[^0-9]+//" | cut -d " " -f 1 | while read p; do
+      kill $p || exit_1_banner "Cannot kill process with PID: $p"
     done
   done
   rm -f $pidFile


### PR DESCRIPTION
I find all the helper scripts, like createClient and startClient, very helpful. However, after spending some time with them, I found it a pain having to a) stop clients started with startClient and b) modifying images created with createClient while troubleshooting, testing, and otherwise getting things to run. For that reason I've added two scripts: stopClient and editClient. Hope you find them just as useful...

For stopClient to work, I had to modify startClient so as to capture PIDs of the launched processes. Those PIDs are stored in the same directory as the client image, in file ${imageName}${postFix}.pid. There's only one PID stored in each file. stopClient then uses PIDs in those files to find processes within the same PID group and terminate them using TERM signal. The only difference with the other *Client scripts is that - if you don't specify postFix using -p option, stopClient will use *.pid files as opposed to ${imageName}${postFix}.pid when -p _is_ specified, thus terminating all instances of the client.

Lastly, editClient is much like startClient, except that it accepts an extra argument - a ST script to be evaluated. It then launches pharo with ${clientName}${postFix}.image in headless mode and evaluates the script, saving the image after successful evaluation.

Both were created by chopping down existing scripts, so things should work across all platforms. I have only tested on Mac and Debian/Ubuntu.